### PR TITLE
Remove the local.properties to fix the sdk android path, flutter build the correct one if it doesn't exist : 

### DIFF
--- a/example/android/local.properties
+++ b/example/android/local.properties
@@ -1,3 +1,0 @@
-sdk.dir=/Users/Florian/Library/Android/sdk
-flutter.sdk=/Users/Florian/Documents/flutter
-flutter.buildMode=debug


### PR DESCRIPTION
Warning! This package referenced a Flutter repository via the .packages file that is
no longer available. The repository from which the 'flutter' tool is currently
executing will be used instead.
  running Flutter tool: /opt/flutter
  previous reference  : /Users/Florian/Documents/flutter
This can happen if you deleted or moved your copy of the Flutter repository, or
if it was on a volume that is no longer mounted or has been mounted at a
different location. Please check your system path to verify that you are running
the expected version (run 'flutter --version' to see which flutter is on your path).

Your application could not be compiled, because its dependencies could not be established.
The following Dart file:
  /home/samtong/WiFiFlutter/example/lib/main.dart
...refers, in an import, to the following library:
  /Users/Florian/Documents/flutter/packages/flutter/lib/material.dart
Unfortunately, that library does not appear to exist on your file system.