### PR TITLE
Set SDK max to <3.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,9 @@ version: 0.0.1
 author:
 homepage:
 
+environment:
+   sdk: <3.0.0
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
Fix for Flutter v0.6.0, now integrating Dart 2 build (2.1.0-dev.0.0).

According to https://github.com/flutter/flutter/wiki/Changelog, "package and plugin authors should ensure their pubspec.yaml files include a Dart SDK constraint with an upper bound of <3.0.0"