### PR TITLE
Use the id network from updateNetwork to get the connected status

### DIFF
--- a/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -783,7 +783,7 @@ public class WifiIotPlugin implements MethodCallHandler, EventChannel.StreamHand
         for (int i = 0; i < 30; i++) {
             int networkId = moWiFi.getConnectionInfo().getNetworkId();
             if (networkId != -1) {
-                connected = networkId == conf.networkId;
+                connected = networkId == updateNetwork;
                 break;
             }
             try {


### PR DESCRIPTION
This fixes the issue #20 
The 'updateNetwork' variable holds the id from the added network both the first time the network is added and when the network already existed.