### PR TITLE
Fix argument name for removeWifiNetwork

### DIFF
--- a/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -652,7 +652,7 @@ public class WifiIotPlugin implements MethodCallHandler, EventChannel.StreamHand
 
     /// This method will remove the WiFi network as per the passed SSID from the device list
     private void removeWifiNetwork(MethodCall poCall, Result poResult) {
-        String prefix_ssid = poCall.argument("prefix_ssid");
+        String prefix_ssid = poCall.argument("ssid");
         if (prefix_ssid.equals("")) {
             poResult.error("Error", "No prefix SSID was given!", null);
         }


### PR DESCRIPTION
Fix the argument name in removeWifiNetwork.

https://github.com/alternadom/WiFiFlutter/blob/6211431de4d2f8037a8e411ca17999200ae8ecc0/lib/wifi_iot.dart#L308-L318

https://github.com/alternadom/WiFiFlutter/blob/6211431de4d2f8037a8e411ca17999200ae8ecc0/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java#L654-L658