### PR TITLE
Fix: java.lang.RuntimeException: Methods marked with @UiThread must b…

### DIFF
--- a/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Handler;
+import android.os.Looper;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
@@ -534,8 +536,15 @@ public class WifiIotPlugin implements MethodCallHandler, EventChannel.StreamHand
                 String security = poCall.argument("security");
                 Boolean joinOnce = poCall.argument("join_once");
 
-                boolean connected = connectTo(ssid, password, security, joinOnce);
-                poResult.success(connected);
+                final boolean connected = connectTo(ssid, password, security, joinOnce);
+                
+				final Handler handler = new Handler(Looper.getMainLooper());
+                handler.post(new Runnable() {
+                    @Override
+                    public void run () {
+                        poResult.success(connected);
+                    }
+                });
             }
         }.start();
     }


### PR DESCRIPTION
Fix: java.lang.RuntimeException: Methods marked with @UiThread must be executed on the main thread.

Encountered with flutter version:
Flutter 1.7.3 • channel dev • https://github.com/flutter/flutter.git
Framework • revision 362b999b90 (4 days ago) • 2019-06-07 12:43:27 -0700
Engine • revision 0602dbb275
Tools • Dart 2.3.2 (build 2.3.2-dev.0.1 6e0d978505)
