### PR TITLE
Implements d6ee479 for findAndConnect

### DIFF
--- a/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -580,8 +580,15 @@ public class WifiIotPlugin implements MethodCallHandler, EventChannel.StreamHand
                     }
                 }
 
-                boolean connected = connectTo(ssid, password, security, joinOnce);
-                poResult.success(connected);
+                final boolean connected = connectTo(ssid, password, security, joinOnce);
+
+				final Handler handler = new Handler(Looper.getMainLooper());
+                handler.post(new Runnable() {
+                    @Override
+                    public void run () {
+                        poResult.success(connected);
+                    }
+                });
             }
         }.start();
     }


### PR DESCRIPTION
d6ee479 fixes the problem for ```connect```. Add the fix to ```findAndConnect```.