### PR TITLE
Fix for connect() call when the WiFi network doesn't exist

### DIFF
--- a/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/ios/Classes/SwiftWifiIotPlugin.swift
@@ -143,9 +143,14 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
                         return
                     }
                 } else {
-                    print("Connected to " + self.getSSID()!)
-                    // ssid check is required because if wifi not found (could not connect) there seems to be no error given
-                    result(self.getSSID()! == sSSID)
+                    if (self.getSSID() == nil) {
+                        print("WiFi network not found")
+                        result(false)
+                    } else {
+                        print("Connected to " + self.getSSID()!)
+                        // ssid check is required because if wifi not found (could not connect) there seems to be no error given
+                        result(self.getSSID()! == sSSID)
+                    }
                     return
                 }
             }


### PR DESCRIPTION
This fixed a crash on unpacking ``getSSID()!``. When the WiFi network doesn't exist, ``error`` is nil so we need to check the ``getSSID()`` result for ``nil``.