### PR TITLE
Publish showWritePermissionSettings as part of public API

### DIFF
--- a/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -248,6 +248,9 @@ public class WifiIotPlugin implements FlutterPlugin, ActivityAware, MethodCallHa
             case "setMACFiltering":
                 setMACFiltering(poCall, poResult);
                 break;
+            case "showWritePermissionSettings":
+                showWritePermissionSettings(poCall, poResult);
+                break;
             default:
                 poResult.notImplemented();
                 break;
@@ -433,6 +436,20 @@ public class WifiIotPlugin implements FlutterPlugin, ActivityAware, MethodCallHa
     private void setWiFiAPEnabled(MethodCall poCall, Result poResult) {
         boolean enabled = poCall.argument("state");
         moWiFiAPManager.setWifiApEnabled(null, enabled);
+        poResult.success(null);
+    }
+
+    /**
+     * Show write permission settings page to user
+     * Depending on Android version and application these may be needed
+     * to perform certain WiFi configurations that require WRITE_SETTINGS
+     * which require a double opt-in, not just presence in manifest.
+     * *** showWritePermissionSettings :
+     * param boolean force, if true shows always, if false only if permissions are not already granted
+     */
+    private void showWritePermissionSettings(MethodCall poCall, Result poResult) {
+        boolean force = poCall.argument("force");
+        moWiFiAPManager.showWritePermissionSettings(force);
         poResult.success(null);
     }
 

--- a/android/src/main/java/info/whitebyte/hotspotmanager/WifiApManager.java
+++ b/android/src/main/java/info/whitebyte/hotspotmanager/WifiApManager.java
@@ -70,6 +70,9 @@ public class WifiApManager {
      */
     public boolean setWifiApEnabled(WifiConfiguration wifiConfig, boolean enabled) {
         try {
+            // Calling setWifiApEnabled requires MANAGE_WRITE_SETTINGS permissions, so check and request if needed
+            showWritePermissionSettings(false);
+
             if (enabled) { // disable WiFi in any case
                 mWifiManager.setWifiEnabled(false);
             }

--- a/lib/wifi_iot.dart
+++ b/lib/wifi_iot.dart
@@ -40,6 +40,16 @@ class WiFiForIoTPlugin {
     }
   }
 
+  static void showWritePermissionSettings(bool force) async {
+    Map<String, bool> htArguments = Map();
+    htArguments["force"] = force;
+    try {
+      await _channel.invokeMethod('showWritePermissionSettings', htArguments);
+    } on MissingPluginException catch (e) {
+      print("MissingPluginException : ${e.toString()}");
+    }
+  }
+
   static Future<bool> isWiFiAPSSIDHidden() async {
     Map<String, String> htArguments = Map();
     bool bResult;


### PR DESCRIPTION
showWritePermissionSettings, a method that starts the intent to achieve
MANAGE_WRITE_SETTINGS, was present in the plugin already from the beginning
in WifiApManager class but was not part of the API and therefore not usable
directly.

This MR publishes it so it can be effectively used by code that requires
such permissions (ie. configuration of AP on devices) without the need
to have double code.

Closes #111 