### PR TITLE
Call startScan on Android P and Higher

### DIFF
--- a/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -605,8 +605,7 @@ public class WifiIotPlugin implements FlutterPlugin, ActivityAware, MethodCallHa
                 moActivity.requestPermissions(new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION);
             }
 
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P)
-                moWiFi.startScan();
+            moWiFi.startScan();
 
             poResult.success(handleNetworkScanResult().toString());
 


### PR DESCRIPTION
Android P *does* allow for startScan call, just throttles how often it can be done per two-minute period. This removes a conditional that prevented startScan from being called at all on that version.

#138

Relevant docs:
https://developer.android.com/guide/topics/connectivity/wifi-scan#wifi-scan-permissions