### PR TITLE
refactor(ios): handle deprecation of `CNCopyCurrentNetworkInfo `

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Becareful, some commands as no effect on iOS because Apple don't let us to do wh
 | Registering / Unregistering a WiFi network            | :white_check_mark:(5c) |  :warning:(2)  |
 | Getting informations like :                           | :white_check_mark: |  :warning:(3)  |
 | - SSID                                                | :white_check_mark: |  :white_check_mark:  |
-| - BSSID                                               | :white_check_mark: |  :x:  |
+| - BSSID                                               | :white_check_mark: |  :white_check_mark:  |
 | - Current signal strength                             | :white_check_mark: |  :x:  |
 | - Frequency                                           | :white_check_mark: |  :x:  |
 | - IP                                                  | :white_check_mark: |  :question:(4)  |

--- a/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/ios/Classes/SwiftWifiIotPlugin.swift
@@ -235,11 +235,17 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
 
     private func getSSID() -> String? {
         var ssid: String?
-        if let interfaces = CNCopySupportedInterfaces() as NSArray? {
-            for interface in interfaces {
-                if let interfaceInfo = CNCopyCurrentNetworkInfo(interface as! CFString) as NSDictionary? {
-                    ssid = interfaceInfo[kCNNetworkInfoKeySSID as String] as? String
-                    break
+        if #available(iOS 14.0, *) {
+            NEHotspotNetwork.fetchCurrent(completionHandler: { currentNetwork in
+                ssid = currentNetwork?.ssid
+            })
+        } else {
+            if let interfaces = CNCopySupportedInterfaces() as NSArray? {
+                for interface in interfaces {
+                    if let interfaceInfo = CNCopyCurrentNetworkInfo(interface as! CFString) as NSDictionary? {
+                        ssid = interfaceInfo[kCNNetworkInfoKeySSID as String] as? String
+                        break
+                    }
                 }
             }
         }
@@ -248,11 +254,17 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
 
     private func getBSSID() -> String? {
         var bssid: String?
-        if let interfaces = CNCopySupportedInterfaces() as NSArray? {
-            for interface in interfaces {
-                if let interfaceInfo = CNCopyCurrentNetworkInfo(interface as! CFString) as NSDictionary? {
-                    bssid = interfaceInfo[kCNNetworkInfoKeyBSSID as String] as? String
-                    break
+        if #available(iOS 14.0, *) {
+            NEHotspotNetwork.fetchCurrent(completionHandler: { currentNetwork in
+                bssid = currentNetwork?.bssid
+            })
+        } else {
+            if let interfaces = CNCopySupportedInterfaces() as NSArray? {
+                for interface in interfaces {
+                    if let interfaceInfo = CNCopyCurrentNetworkInfo(interface as! CFString) as NSDictionary? {
+                        bssid = interfaceInfo[kCNNetworkInfoKeyBSSID as String] as? String
+                        break
+                    }
                 }
             }
         }


### PR DESCRIPTION
Using `NEHotspotNetwork.fetchCurrent` instead

Closes #142 #105 #75 #121