### PR TITLE
fix(ios): getSSID and getBSSID always returning null

### DIFF
--- a/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/ios/Classes/SwiftWifiIotPlugin.swift
@@ -43,7 +43,9 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
                 }
                 break;
             case "getBSSID":
-                result(getBSSID())
+                getBSSID { (bSSID) in
+                    result(bSSID)
+                }
                 break;
             case "getCurrentSignalStrength":
                 getCurrentSignalStrength(result: result)
@@ -234,7 +236,7 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func getSSID(result: @escaping (String?)->()) {
+    private func getSSID(result: @escaping (String?) -> ()) {
         if #available(iOS 14.0, *) {
             NEHotspotNetwork.fetchCurrent(completionHandler: { currentNetwork in
                 result(currentNetwork?.ssid);
@@ -252,23 +254,22 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func getBSSID() -> String? {
-        var bssid: String?
+    private func getBSSID(result: @escaping (String?) -> ()) {
         if #available(iOS 14.0, *) {
             NEHotspotNetwork.fetchCurrent(completionHandler: { currentNetwork in
-                bssid = currentNetwork?.bssid
+                result(currentNetwork?.bssid);
             })
         } else {
             if let interfaces = CNCopySupportedInterfaces() as NSArray? {
                 for interface in interfaces {
                     if let interfaceInfo = CNCopyCurrentNetworkInfo(interface as! CFString) as NSDictionary? {
-                        bssid = interfaceInfo[kCNNetworkInfoKeyBSSID as String] as? String
-                        break
+                        result(interfaceInfo[kCNNetworkInfoKeyBSSID as String] as? String)
+                        return
                     }
                 }
             }
+            result(nil)
         }
-        return bssid
     }
 
     private func getCurrentSignalStrength(result: FlutterResult) {


### PR DESCRIPTION
This patch adresses issues 
https://github.com/alternadom/WiFiFlutter/issues/161
and
https://github.com/alternadom/WiFiFlutter/issues/105

It adds a callback function to getSSID, which will resolve the result.
This is since NEHotspotNetwork.fetchCurrent's completionHandler is escaping. As a result ssid will never be set.