### PR TITLE
feat(ios): getIP implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ coverage/
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+
+# FVM
+.fvm

--- a/README.md
+++ b/README.md
@@ -22,29 +22,25 @@ Becareful, some commands as no effect on iOS because Apple don't let us to do wh
 ## WiFi connections
 |                      Description                      |      Android       |         iOS          |
 | :---------------------------------------------------- | :----------------: | :------------------: |
-| Enabling / Disabling WiFi module                      | :warning:(5a) |  :x:  |
+| Enabling / Disabling WiFi module                      | :warning:(3a) |  :x:  |
 | Getting WiFi status                                   | :white_check_mark: |  :x:  |
 | Scanning for networks, with "already-associated" flag | :white_check_mark: |  :x:  |
-| Connecting / Disconnecting on a network in WPA / WEP  | :white_check_mark:(5b) |  :white_check_mark:(1)  |
-| Registering / Unregistering a WiFi network            | :white_check_mark:(5c) |  :warning:(2)  |
-| Getting informations like :                           | :white_check_mark: |  :warning:(3)  |
+| Connecting / Disconnecting on a network in WPA / WEP  | :white_check_mark:(3b) |  :white_check_mark:(1)  |
+| Registering / Unregistering a WiFi network            | :white_check_mark:(3c) |  :warning:(2)  |
+| Getting informations like :                           | :white_check_mark: |  :white_check_mark:  |
 | - SSID                                                | :white_check_mark: |  :white_check_mark:  |
 | - BSSID                                               | :white_check_mark: |  :white_check_mark:  |
 | - Current signal strength                             | :white_check_mark: |  :x:  |
 | - Frequency                                           | :white_check_mark: |  :x:  |
-| - IP                                                  | :white_check_mark: |  :question:(4)  |
+| - IP                                                  | :white_check_mark: |  :white_check_mark:  |
 
 :white_check_mark:(1) : On iOS, you can only disconnect from a network which has been added by your app. In order to disconnect from a system network, you have to connect to an other!
 
 :warning:(2) : On iOS, you can forget a WiFi network by connecting to it with the joinOnce flag to true!
 
-:warning:(3) : On iOS, you can just getting the SSID, or maybe(probably) I'm missing something! 
-
-:question:(4) : I think there is a way to get the IP address but for now, this is not implemented..
-
-:warning:(5): Wifi API changes in Android SDK >= 29, restricts certain behaviour:
+:warning:(3): Wifi API changes in Android SDK >= 29, restricts certain behaviour:
   * a. Enable/Disable Wifi Module is deprecated and will always fail [[docs](https://developer.android.com/reference/android/net/wifi/WifiManager#setWifiEnabled(boolean))]. If you  want to open "Wifi Setting" in that case then, set the `shouldOpenSettings: true` when calling `setEnabled`.
-  * b. For Connecting to Wifi, WEP security is deprecated and will always fail, also the network will be disconnected when the app is closed (if permanent network is required(Check :warning:(5c)), use "Register Network" feature) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-bootstrap))]. By default the connection would not have internet access, to connect to network with internet user `withInternet` which is a different API underneath (this API will not disconnect to network after app closes) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-suggest)].
+  * b. For Connecting to Wifi, WEP security is deprecated and will always fail, also the network will be disconnected when the app is closed (if permanent network is required(Check :warning:(3c)), use "Register Network" feature) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-bootstrap))]. By default the connection would not have internet access, to connect to network with internet user `withInternet` which is a different API underneath (this API will not disconnect to network after app closes) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-suggest)].
   * c. Registering Wifi Network, will require user approval - and the network saved would not be controlled by the app (for deletion, updation, etc) [[docs](https://developer.android.com/guide/topics/connectivity/wifi-save-network-passpoint-config)];
 
 Additional Wifi protocols on Android side like - Wifi Direct, Wifi Aware, etc are in active discussion at [#140](https://github.com/alternadom/WiFiFlutter/issues/140). Encourage you to engage if you want this features.

--- a/ios/Classes/SwiftWifiIotPlugin.swift
+++ b/ios/Classes/SwiftWifiIotPlugin.swift
@@ -43,7 +43,9 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
                 }
                 break;
             case "getBSSID":
-                result(getBSSID())
+                getBSSID { (bSSID) in
+                    result(bSSID)
+                }
                 break;
             case "getCurrentSignalStrength":
                 getCurrentSignalStrength(result: result)
@@ -234,7 +236,7 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func getSSID(result: @escaping (String?)->()) {
+    private func getSSID(result: @escaping (String?) -> ()) {
         if #available(iOS 14.0, *) {
             NEHotspotNetwork.fetchCurrent(completionHandler: { currentNetwork in
                 result(currentNetwork?.ssid);
@@ -252,23 +254,22 @@ public class SwiftWifiIotPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func getBSSID() -> String? {
-        var bssid: String?
+    private func getBSSID(result: @escaping (String?) -> ()) {
         if #available(iOS 14.0, *) {
             NEHotspotNetwork.fetchCurrent(completionHandler: { currentNetwork in
-                bssid = currentNetwork?.bssid
+                result(currentNetwork?.bssid);
             })
         } else {
             if let interfaces = CNCopySupportedInterfaces() as NSArray? {
                 for interface in interfaces {
                     if let interfaceInfo = CNCopyCurrentNetworkInfo(interface as! CFString) as NSDictionary? {
-                        bssid = interfaceInfo[kCNNetworkInfoKeyBSSID as String] as? String
-                        break
+                        result(interfaceInfo[kCNNetworkInfoKeyBSSID as String] as? String)
+                        return
                     }
                 }
             }
+            result(nil)
         }
-        return bssid
     }
 
     private func getCurrentSignalStrength(result: FlutterResult) {


### PR DESCRIPTION
This uses the same approach as network_info_plus:

https://github.com/fluttercommunity/plus_plugins/blob/a1b18402790b65f4f23cbb5d6ed7bb248480a70e/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfoPlusPlugin.m#L54

The functionality is split across 2 functions, so we could as well implement getIPv6 by calling getNetworkInterface with AF_INET6 instead of AF_INET