### PR TITLE
fix(wifi_iot): Fix connection to registered network on Android < 10 (Q) (Extended)

### DIFF
--- a/packages/wifi_iot/android/build.gradle
+++ b/packages/wifi_iot/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 30
-
+    namespace "com.alternadom.wifiiot"
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -1439,7 +1439,7 @@ public class WifiIotPlugin
           registeredNetwork = wifiConfig.networkId;
           //only try to update the configuration if joinOnce is false
           //otherwise use the new add/update method
-          if(joinOnce == false) {
+          if(joinOnce != null && !joinOnce.booleanValue()) {
             updateNetwork = moWiFi.updateNetwork(conf);
             //required for pre API 26
             moWiFi.saveConfiguration();
@@ -1583,7 +1583,7 @@ public class WifiIotPlugin
       // to discard false positives like auth error
       if (networkId != -1 && netState == SupplicantState.COMPLETED) {
         connected = networkId == updateNetwork;
-        if(connected == true) {
+        if(connected) {
           break;
         } else {
           disconnect = moWiFi.disconnect();

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -14,7 +14,6 @@ import android.net.NetworkCapabilities;
 import android.net.NetworkRequest;
 import android.net.wifi.ScanResult;
 import android.net.wifi.SoftApConfiguration;
-import android.net.wifi.SupplicantState;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
@@ -49,6 +48,8 @@ import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import java.util.Random;
+import android.net.wifi.SupplicantState;
 
 /** WifiIotPlugin */
 public class WifiIotPlugin
@@ -73,6 +74,8 @@ public class WifiIotPlugin
   private List<WifiNetworkSuggestion> networkSuggestions;
   private List<String> ssidsToBeRemovedOnExit = new ArrayList<String>();
   private List<WifiNetworkSuggestion> suggestionsToBeRemovedOnExit = new ArrayList<>();
+  //last connected network ID from outside the app
+  private int lastConnectedNetworkId = -1;
 
   // Permission request management
   private boolean requestingPermission = false;
@@ -98,6 +101,21 @@ public class WifiIotPlugin
 
   // cleanup
   private void cleanup() {
+    removeAddedNetworks();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !suggestionsToBeRemovedOnExit.isEmpty()) {
+      moWiFi.removeNetworkSuggestions(suggestionsToBeRemovedOnExit);
+    }
+    // setting all members to null to avoid memory leaks
+    lastConnectedNetworkId = -1;
+    channel = null;
+    eventChannel = null;
+    moActivity = null;
+    moContext = null;
+    moWiFi = null;
+    moWiFiAPManager = null;
+  }
+
+  private void removeAddedNetworks() {
     if (!ssidsToBeRemovedOnExit.isEmpty()) {
       List<WifiConfiguration> wifiConfigList = moWiFi.getConfiguredNetworks();
       for (String ssid : ssidsToBeRemovedOnExit) {
@@ -108,16 +126,7 @@ public class WifiIotPlugin
         }
       }
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !suggestionsToBeRemovedOnExit.isEmpty()) {
-      moWiFi.removeNetworkSuggestions(suggestionsToBeRemovedOnExit);
-    }
-    // setting all members to null to avoid memory leaks
-    channel = null;
-    eventChannel = null;
-    moActivity = null;
-    moContext = null;
-    moWiFi = null;
-    moWiFiAPManager = null;
+    ssidsToBeRemovedOnExit.clear();
   }
 
   /** Plugin registration. This is used for registering with v1 Android embedding. */
@@ -968,7 +977,7 @@ public class WifiIotPlugin
       android.net.wifi.WifiConfiguration conf =
           generateConfiguration(ssid, bssid, password, security, isHidden);
 
-      int updateNetwork = registerWifiNetworkDeprecated(conf);
+      int updateNetwork = registerWifiNetworkDeprecated(conf, false);
 
       if (updateNetwork == -1) {
         poResult.error("Error", "Error updating network configuration", "");
@@ -1107,6 +1116,10 @@ public class WifiIotPlugin
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
       //noinspection deprecation
       disconnected = moWiFi.disconnect();
+      if(lastConnectedNetworkId != -1) {
+        //android 8.1 won't automatically reconnect to the previous network if it shares the same SSID
+        moWiFi.enableNetwork(lastConnectedNetworkId, true);
+      }
     } else {
       if (networkCallback != null) {
         final ConnectivityManager connectivityManager =
@@ -1186,13 +1199,23 @@ public class WifiIotPlugin
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
       List<android.net.wifi.WifiConfiguration> mWifiConfigList = moWiFi.getConfiguredNetworks();
       for (android.net.wifi.WifiConfiguration wifiConfig : mWifiConfigList) {
-        String comparableSSID = ('"' + prefix_ssid); //Add quotes because wifiConfig.SSID has them
-        if (wifiConfig.SSID.startsWith(comparableSSID)) {
-          moWiFi.removeNetwork(wifiConfig.networkId);
-          moWiFi.saveConfiguration();
-          removed = true;
-          break;
+        String comparableSSID = ('"' + prefix_ssid + '"'); //Add quotes because wifiConfig.SSID has them
+        if (wifiConfig.SSID.equals(comparableSSID)) {
+          Boolean isRemoved = moWiFi.removeNetwork(wifiConfig.networkId);
+          if(isRemoved) {
+            moWiFi.saveConfiguration();
+            removed = true;
+            //if the last connected network was our app's network, reset the last connected network
+            if(wifiConfig.networkId == lastConnectedNetworkId) {
+              lastConnectedNetworkId = -1;
+            }
+          }
+          //multiple networks with the same SSID could be removed
         }
+      }
+      if(lastConnectedNetworkId != -1) {
+        //android 8.1 won't automatically reconnect to the previous network if it shares the same SSID
+        moWiFi.enableNetwork(lastConnectedNetworkId, true);
       }
     }
 
@@ -1399,7 +1422,7 @@ public class WifiIotPlugin
   }
 
   @SuppressWarnings("deprecation")
-  private int registerWifiNetworkDeprecated(android.net.wifi.WifiConfiguration conf) {
+  private int registerWifiNetworkDeprecated(android.net.wifi.WifiConfiguration conf, Boolean joinOnce) {
     int updateNetwork = -1;
     int registeredNetwork = -1;
 
@@ -1414,7 +1437,43 @@ public class WifiIotPlugin
                 || wifiConfig.BSSID.equals(conf.BSSID))) {
           conf.networkId = wifiConfig.networkId;
           registeredNetwork = wifiConfig.networkId;
-          updateNetwork = moWiFi.updateNetwork(conf);
+          //only try to update the configuration if joinOnce is false
+          //otherwise use the new add/update method
+          if(joinOnce == false) {
+            updateNetwork = moWiFi.updateNetwork(conf);
+            //required for pre API 26
+            moWiFi.saveConfiguration();
+          }
+          //Android 6.0 and higher no longer allows you to update a network that wasn't created
+          //from our app, nor delete it, nor add a network with the same SSID
+          //See https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-network
+          if(updateNetwork == -1) {
+            //we add some random number to the conf SSID, add that network, then change the SSID
+            // back to circumvent the issue
+            String ssid = conf.SSID;
+            Random random = new Random(System.currentTimeMillis());
+            //loop in the rare case that the generated ssid already exists
+            for (int i = 0; i < 20; i++) {
+              int randomInteger = random.nextInt(10000);
+              //create a valid SSID with max length of 32
+              String ssidRandomized = ssid+randomInteger;
+              int ssidRandomizedExtraLength = ssidRandomized.length()-32;
+              if(ssidRandomizedExtraLength > 0) {
+                ssidRandomized = ssid.substring(0,ssid.length()-ssidRandomizedExtraLength)+randomInteger;
+              }
+              conf.SSID = "\"" + ssidRandomized + "\"";
+              updateNetwork = moWiFi.addNetwork(conf); // Add my wifi with another name
+              conf.SSID = ssid;
+              conf.networkId = updateNetwork;
+              updateNetwork = moWiFi.updateNetwork(conf); // After my wifi is added with another name, I change it to the desired name
+              moWiFi.saveConfiguration();
+              if(updateNetwork != -1) {
+                break;
+              }
+            }
+          }
+          //no need to continue looping
+          break;
         }
       }
     }
@@ -1422,6 +1481,7 @@ public class WifiIotPlugin
     /// If network not already in configured networks add new network
     if (updateNetwork == -1) {
       updateNetwork = moWiFi.addNetwork(conf);
+      conf.networkId = updateNetwork;
       moWiFi.saveConfiguration();
     }
 
@@ -1491,7 +1551,7 @@ public class WifiIotPlugin
     android.net.wifi.WifiConfiguration conf =
         generateConfiguration(ssid, bssid, password, security, isHidden);
 
-    int updateNetwork = registerWifiNetworkDeprecated(conf);
+    int updateNetwork = registerWifiNetworkDeprecated(conf, joinOnce);
 
     if (updateNetwork == -1) {
       return false;
@@ -1499,6 +1559,9 @@ public class WifiIotPlugin
 
     if (joinOnce != null && joinOnce.booleanValue()) {
       ssidsToBeRemovedOnExit.add(conf.SSID);
+    }
+    if(lastConnectedNetworkId == -1) {
+      lastConnectedNetworkId = moWiFi.getConnectionInfo().getNetworkId();
     }
 
     boolean disconnect = moWiFi.disconnect();
@@ -1510,24 +1573,38 @@ public class WifiIotPlugin
     if (!enabled) return false;
 
     boolean connected = false;
+    int networkId = -1;
     for (int i = 0; i < 20; i++) {
       WifiInfo currentNet = moWiFi.getConnectionInfo();
-      int networkId = currentNet.getNetworkId();
+      networkId = currentNet.getNetworkId();
       SupplicantState netState = currentNet.getSupplicantState();
 
       // Wait for connection to reach state completed
       // to discard false positives like auth error
       if (networkId != -1 && netState == SupplicantState.COMPLETED) {
         connected = networkId == updateNetwork;
-        break;
+        if(connected == true) {
+          break;
+        } else {
+          disconnect = moWiFi.disconnect();
+          if (!disconnect) {
+            break;
+          }
+
+          enabled = moWiFi.enableNetwork(updateNetwork, true);
+          break;
+        }
       }
       try {
-        Thread.sleep(500);
+        Thread.sleep(1000);
       } catch (InterruptedException ignored) {
         break;
       }
     }
-
+    if(!connected && lastConnectedNetworkId != -1) {
+      //android 8.1 won't automatically reconnect to the previous network if it shares the same SSID
+      moWiFi.enableNetwork(lastConnectedNetworkId, true);
+    }
     return connected;
   }
 }

--- a/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
+++ b/packages/wifi_iot/android/src/main/java/com/alternadom/wifiiot/WifiIotPlugin.java
@@ -26,12 +26,15 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
+
 import info.whitebyte.hotspotmanager.ClientScanResult;
 import info.whitebyte.hotspotmanager.FinishScanListener;
 import info.whitebyte.hotspotmanager.WIFI_AP_STATE;
 import info.whitebyte.hotspotmanager.WifiApManager;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -40,26 +43,24 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
-import io.flutter.plugin.common.PluginRegistry.ViewDestroyListener;
-import io.flutter.view.FlutterNativeView;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-/** WifiIotPlugin */
+/** WifiIotPlugin (Flutter embedding v2) */
 public class WifiIotPlugin
-    implements FlutterPlugin,
+        implements FlutterPlugin,
         ActivityAware,
         MethodCallHandler,
         EventChannel.StreamHandler,
         RequestPermissionsResultListener {
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
+
   private MethodChannel channel;
   private EventChannel eventChannel;
 
@@ -72,19 +73,18 @@ public class WifiIotPlugin
   private WIFI_AP_STATE localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_DISABLED;
   private ConnectivityManager.NetworkCallback networkCallback;
   private List<WifiNetworkSuggestion> networkSuggestions;
-  private List<String> ssidsToBeRemovedOnExit = new ArrayList<String>();
-  private List<WifiNetworkSuggestion> suggestionsToBeRemovedOnExit = new ArrayList<>();
-  //last connected network ID from outside the app
+  private final List<String> ssidsToBeRemovedOnExit = new ArrayList<>();
+  private final List<WifiNetworkSuggestion> suggestionsToBeRemovedOnExit = new ArrayList<>();
+  // last connected network ID from outside the app
   private int lastConnectedNetworkId = -1;
 
   // Permission request management
   private boolean requestingPermission = false;
   private Result permissionRequestResultCallback = null;
-  private ArrayList<Object> permissionRequestCookie = new ArrayList<>();
+  private final ArrayList<Object> permissionRequestCookie = new ArrayList<>();
   private static final int PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_LOAD_WIFI_LIST = 65655435;
   private static final int PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_ON_LISTEN = 65655436;
-  private static final int PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_FIND_AND_CONNECT =
-      65655437;
+  private static final int PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_FIND_AND_CONNECT = 65655437;
   private static final int PERMISSIONS_REQUEST_CODE_ACCESS_NETWORK_STATE_IS_CONNECTED = 65655438;
 
   // initialize members of this class with Context
@@ -129,34 +129,12 @@ public class WifiIotPlugin
     ssidsToBeRemovedOnExit.clear();
   }
 
-  /** Plugin registration. This is used for registering with v1 Android embedding. */
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "wifi_iot");
-    final EventChannel eventChannel =
-        new EventChannel(registrar.messenger(), "plugins.wififlutter.io/wifi_scan");
-    final WifiIotPlugin wifiIotPlugin = new WifiIotPlugin();
-    wifiIotPlugin.initWithActivity(registrar.activity());
-    wifiIotPlugin.initWithContext(registrar.activeContext());
-    eventChannel.setStreamHandler(wifiIotPlugin);
-    channel.setMethodCallHandler(wifiIotPlugin);
-
-    registrar.addViewDestroyListener(
-        new ViewDestroyListener() {
-          @Override
-          public boolean onViewDestroy(FlutterNativeView view) {
-            wifiIotPlugin.cleanup();
-            return false;
-          }
-        });
-    registrar.addRequestPermissionsResultListener(wifiIotPlugin);
-  }
-
+  // ---------- Embedding v2 wiring ----------
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     // initialize method and event channel and set handlers
     channel = new MethodChannel(binding.getBinaryMessenger(), "wifi_iot");
-    eventChannel =
-        new EventChannel(binding.getBinaryMessenger(), "plugins.wififlutter.io/wifi_scan");
+    eventChannel = new EventChannel(binding.getBinaryMessenger(), "plugins.wififlutter.io/wifi_scan");
     channel.setMethodCallHandler(this);
     eventChannel.setStreamHandler(this);
 
@@ -200,18 +178,19 @@ public class WifiIotPlugin
     moActivity = null;
   }
 
+  // ---------- Permissions ----------
   @Override
   public boolean onRequestPermissionsResult(
-      int requestCode, String[] permissions, int[] grantResults) {
+          int requestCode, String[] permissions, int[] grantResults) {
     final boolean wasPermissionGranted =
-        grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+            grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
     switch (requestCode) {
       case PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_LOAD_WIFI_LIST:
         if (wasPermissionGranted) {
           _loadWifiList(permissionRequestResultCallback);
         } else {
           permissionRequestResultCallback.error(
-              "WifiIotPlugin.Permission", "Fine location permission denied", null);
+                  "WifiIotPlugin.Permission", "Fine location permission denied", null);
         }
         requestingPermission = false;
         return true;
@@ -219,7 +198,7 @@ public class WifiIotPlugin
       case PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_ON_LISTEN:
         if (wasPermissionGranted) {
           final EventChannel.EventSink eventSink =
-              (EventChannel.EventSink) permissionRequestCookie.get(0);
+                  (EventChannel.EventSink) permissionRequestCookie.get(0);
           _onListen(eventSink);
         }
         requestingPermission = false;
@@ -231,7 +210,7 @@ public class WifiIotPlugin
           _findAndConnect(poCall, permissionRequestResultCallback);
         } else {
           permissionRequestResultCallback.error(
-              "WifiIotPlugin.Permission", "Fine location permission denied", null);
+                  "WifiIotPlugin.Permission", "Fine location permission denied", null);
         }
         requestingPermission = false;
         return true;
@@ -241,7 +220,7 @@ public class WifiIotPlugin
           _isConnected(permissionRequestResultCallback);
         } else {
           permissionRequestResultCallback.error(
-              "WifiIotPlugin.Permission", "Network state permission denied", null);
+                  "WifiIotPlugin.Permission", "Network state permission denied", null);
         }
         requestingPermission = false;
         return true;
@@ -250,6 +229,7 @@ public class WifiIotPlugin
     return false;
   }
 
+  // ---------- Method channel ----------
   @Override
   public void onMethodCall(MethodCall poCall, Result poResult) {
     switch (poCall.method) {
@@ -303,9 +283,9 @@ public class WifiIotPlugin
           isRegisteredWifiNetwork(poCall, poResult);
         else
           poResult.error(
-              "Error",
-              "isRegisteredWifiNetwork not supported for Android SDK " + Build.VERSION.SDK_INT,
-              null);
+                  "Error",
+                  "isRegisteredWifiNetwork not supported for Android SDK " + Build.VERSION.SDK_INT,
+                  null);
         break;
       case "isWiFiAPEnabled":
         isWiFiAPEnabled(poResult);
@@ -346,348 +326,11 @@ public class WifiIotPlugin
     }
   }
 
-  /**
-   * The network's SSID. Can either be an ASCII string, which must be enclosed in double quotation
-   * marks (e.g., {@code "MyNetwork"}), or a string of hex digits, which are not enclosed in quotes
-   * (e.g., {@code 01a243f405}).
-   */
-  private void getWiFiAPSSID(Result poResult) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
-
-      if (oWiFiConfig != null && oWiFiConfig.SSID != null) {
-        poResult.success(oWiFiConfig.SSID);
-        return;
-      }
-
-      poResult.error("Exception [getWiFiAPSSID]", "SSID not found", null);
-    } else {
-      if (apReservation != null) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-          WifiConfiguration wifiConfiguration = apReservation.getWifiConfiguration();
-          if (wifiConfiguration != null) {
-            poResult.success(wifiConfiguration.SSID);
-          } else {
-            poResult.error(
-                "Exception [getWiFiAPSSID]",
-                "Security type is not WifiConfiguration.KeyMgmt.None or WifiConfiguration.KeyMgmt.WPA2_PSK",
-                null);
-          }
-        } else {
-          SoftApConfiguration softApConfiguration = apReservation.getSoftApConfiguration();
-          poResult.success(softApConfiguration.getSsid());
-        }
-      } else {
-        poResult.error("Exception [getWiFiAPSSID]", "Hotspot is not enabled.", null);
-      }
-    }
-  }
-
-  private void setWiFiAPSSID(MethodCall poCall, Result poResult) {
-    String sAPSSID = poCall.argument("ssid");
-
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
-
-      oWiFiConfig.SSID = sAPSSID;
-
-      moWiFiAPManager.setWifiApConfiguration(oWiFiConfig);
-
-      poResult.success(null);
-    } else {
-      poResult.error(
-          "Exception [setWiFiAPSSID]",
-          "Setting SSID name is not supported on API level >= 26",
-          null);
-    }
-  }
-
-  /**
-   * This is a network that does not broadcast its SSID, so an SSID-specific probe request must be
-   * used for scans.
-   */
-  private void isSSIDHidden(Result poResult) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
-
-      if (oWiFiConfig != null && oWiFiConfig.hiddenSSID) {
-        poResult.success(oWiFiConfig.hiddenSSID);
-        return;
-      }
-
-      poResult.error("Exception [isSSIDHidden]", "Wifi AP not Supported", null);
-    } else {
-      if (apReservation != null) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-          SoftApConfiguration softApConfiguration = apReservation.getSoftApConfiguration();
-          poResult.success(softApConfiguration.isHiddenSsid());
-        } else {
-          WifiConfiguration wifiConfiguration = apReservation.getWifiConfiguration();
-          if (wifiConfiguration != null) {
-            poResult.success(wifiConfiguration.hiddenSSID);
-          } else {
-            poResult.error(
-                "Exception [isSSIDHidden]",
-                "Security type is not WifiConfiguration.KeyMgmt.None or WifiConfiguration.KeyMgmt.WPA2_PSK",
-                null);
-          }
-        }
-      } else {
-        poResult.error("Exception [isSSIDHidden]", "Hotspot is not enabled.", null);
-      }
-    }
-  }
-
-  private void setSSIDHidden(MethodCall poCall, Result poResult) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      boolean isSSIDHidden = poCall.argument("hidden");
-
-      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
-
-      oWiFiConfig.hiddenSSID = isSSIDHidden;
-
-      moWiFiAPManager.setWifiApConfiguration(oWiFiConfig);
-
-      poResult.success(null);
-    } else {
-      poResult.error(
-          "Exception [setSSIDHidden]",
-          "Setting SSID visibility is not supported on API level >= 26",
-          null);
-    }
-  }
-
-  /**
-   * Pre-shared key for use with WPA-PSK. Either an ASCII string enclosed in double quotation marks
-   * (e.g., {@code "abcdefghij"} for PSK passphrase or a string of 64 hex digits for raw PSK.
-   *
-   * <p>When the value of this key is read, the actual key is not returned, just a "*" if the key
-   * has a value, or the null string otherwise.
-   */
-  private void getWiFiAPPreSharedKey(Result poResult) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
-
-      if (oWiFiConfig != null && oWiFiConfig.preSharedKey != null) {
-        poResult.success(oWiFiConfig.preSharedKey);
-        return;
-      }
-
-      poResult.error("Exception", "Wifi AP not Supported", null);
-    } else {
-      if (apReservation != null) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-          WifiConfiguration wifiConfiguration = apReservation.getWifiConfiguration();
-          if (wifiConfiguration != null) {
-            poResult.success(wifiConfiguration.preSharedKey);
-          } else {
-            poResult.error(
-                "Exception [getWiFiAPPreSharedKey]",
-                "Security type is not WifiConfiguration.KeyMgmt.None or WifiConfiguration.KeyMgmt.WPA2_PSK",
-                null);
-          }
-        } else {
-          SoftApConfiguration softApConfiguration = apReservation.getSoftApConfiguration();
-          poResult.success(softApConfiguration.getPassphrase());
-        }
-      } else {
-        poResult.error("Exception [getWiFiAPPreSharedKey]", "Hotspot is not enabled.", null);
-      }
-    }
-  }
-
-  private void setWiFiAPPreSharedKey(MethodCall poCall, Result poResult) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      String sPreSharedKey = poCall.argument("preSharedKey");
-
-      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
-
-      oWiFiConfig.preSharedKey = sPreSharedKey;
-
-      moWiFiAPManager.setWifiApConfiguration(oWiFiConfig);
-
-      poResult.success(null);
-    } else {
-      poResult.error(
-          "Exception [setWiFiAPPreSharedKey]",
-          "Setting WiFi password is not supported on API level >= 26",
-          null);
-    }
-  }
-
-  /**
-   * Gets a list of the clients connected to the Hotspot *** getClientList : param onlyReachables
-   * {@code false} if the list should contain unreachable (probably disconnected) clients, {@code
-   * true} otherwise param reachableTimeout Reachable Timout in miliseconds, 300 is default param
-   * finishListener, Interface called when the scan method finishes
-   */
-  private void getClientList(MethodCall poCall, final Result poResult) {
-    Boolean onlyReachables = false;
-    if (poCall.argument("onlyReachables") != null) {
-      onlyReachables = poCall.argument("onlyReachables");
-    }
-
-    Integer reachableTimeout = 300;
-    if (poCall.argument("reachableTimeout") != null) {
-      reachableTimeout = poCall.argument("reachableTimeout");
-    }
-
-    final Boolean finalOnlyReachables = onlyReachables;
-    FinishScanListener oFinishScanListener =
-        new FinishScanListener() {
-          @Override
-          public void onFinishScan(final ArrayList<ClientScanResult> clients) {
-            try {
-              JSONArray clientArray = new JSONArray();
-
-              for (ClientScanResult client : clients) {
-                JSONObject clientObject = new JSONObject();
-
-                Boolean clientIsReachable = client.isReachable();
-                Boolean shouldReturnCurrentClient = true;
-                if (finalOnlyReachables.booleanValue()) {
-                  if (!clientIsReachable.booleanValue()) {
-                    shouldReturnCurrentClient = Boolean.valueOf(false);
-                  }
-                }
-                if (shouldReturnCurrentClient.booleanValue()) {
-                  try {
-                    clientObject.put("IPAddr", client.getIpAddr());
-                    clientObject.put("HWAddr", client.getHWAddr());
-                    clientObject.put("Device", client.getDevice());
-                    clientObject.put("isReachable", client.isReachable());
-                  } catch (JSONException e) {
-                    poResult.error("Exception", e.getMessage(), null);
-                  }
-                  clientArray.put(clientObject);
-                }
-              }
-              poResult.success(clientArray.toString());
-            } catch (Exception e) {
-              poResult.error("Exception", e.getMessage(), null);
-            }
-          }
-        };
-
-    if (reachableTimeout != null) {
-      moWiFiAPManager.getClientList(onlyReachables, reachableTimeout, oFinishScanListener);
-    } else {
-      moWiFiAPManager.getClientList(onlyReachables, oFinishScanListener);
-    }
-  }
-
-  /**
-   * Return whether Wi-Fi AP is enabled or disabled. *** isWifiApEnabled : return {@code true} if
-   * Wi-Fi AP is enabled
-   */
-  private void isWiFiAPEnabled(Result poResult) {
-
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      try {
-        poResult.success(moWiFiAPManager.isWifiApEnabled());
-      } catch (SecurityException e) {
-        Log.e(WifiIotPlugin.class.getSimpleName(), e.getMessage(), null);
-        poResult.error("Exception [isWiFiAPEnabled]", e.getMessage(), null);
-      }
-    } else {
-      poResult.success(apReservation != null);
-    }
-  }
-
-  /**
-   * Start AccessPoint mode with the specified configuration. If the radio is already running in AP
-   * mode, update the new configuration Note that starting in access point mode disables station
-   * mode operation *** setWifiApEnabled : param wifiConfig SSID, security and channel details as
-   * part of WifiConfiguration return {@code true} if the operation succeeds, {@code false}
-   * otherwise
-   */
-  private void setWiFiAPEnabled(MethodCall poCall, final Result poResult) {
-    boolean enabled = poCall.argument("state");
-
-    /** Using LocalOnlyHotspotCallback when setting WiFi AP state on API level >= 29 */
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      final boolean result = moWiFiAPManager.setWifiApEnabled(null, enabled);
-      poResult.success(result);
-    } else {
-      if (enabled) {
-        localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_ENABLING;
-        moWiFi.startLocalOnlyHotspot(
-            new WifiManager.LocalOnlyHotspotCallback() {
-              @Override
-              public void onStarted(WifiManager.LocalOnlyHotspotReservation reservation) {
-                super.onStarted(reservation);
-                apReservation = reservation;
-                localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_ENABLED;
-                poResult.success(true);
-              }
-
-              @Override
-              public void onStopped() {
-                super.onStopped();
-                if (apReservation != null) {
-                  apReservation.close();
-                }
-                apReservation = null;
-                localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_DISABLED;
-                Log.d(WifiIotPlugin.class.getSimpleName(), "LocalHotspot Stopped.");
-              }
-
-              @Override
-              public void onFailed(int reason) {
-                super.onFailed(reason);
-                if (apReservation != null) {
-                  apReservation.close();
-                }
-                apReservation = null;
-                localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_FAILED;
-                Log.d(
-                    WifiIotPlugin.class.getSimpleName(),
-                    "LocalHotspot failed with code: " + String.valueOf(reason));
-                poResult.success(false);
-              }
-            },
-            new Handler());
-      } else {
-        localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_DISABLING;
-        if (apReservation != null) {
-          apReservation.close();
-          apReservation = null;
-          poResult.success(true);
-        } else {
-          Log.e(
-              WifiIotPlugin.class.getSimpleName(), "Can't disable WiFi AP, apReservation is null.");
-          poResult.success(false);
-        }
-        localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_DISABLED;
-      }
-    }
-  }
-
-  /**
-   * Show write permission settings page to user Depending on Android version and application these
-   * may be needed to perform certain WiFi configurations that require WRITE_SETTINGS which require
-   * a double opt-in, not just presence in manifest. *** showWritePermissionSettings : param boolean
-   * force, if true shows always, if false only if permissions are not already granted
-   */
-  private void showWritePermissionSettings(MethodCall poCall, Result poResult) {
-    boolean force = poCall.argument("force");
-    moWiFiAPManager.showWritePermissionSettings(force);
-    poResult.success(null);
-  }
-
-  /** Gets the Wi-Fi enabled state. *** getWifiApState : return {link WIFI_AP_STATE} */
-  private void getWiFiAPState(Result poResult) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      poResult.success(moWiFiAPManager.getWifiApState().ordinal());
-    } else {
-      poResult.success(localOnlyHotspotState);
-    }
-  }
-
+  // ---------- Event channel ----------
   @Override
   public void onListen(Object o, EventChannel.EventSink eventSink) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-        && moContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            && moContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED) {
       if (requestingPermission) {
         return;
@@ -696,18 +339,12 @@ public class WifiIotPlugin
       permissionRequestCookie.clear();
       permissionRequestCookie.add(eventSink);
       moActivity.requestPermissions(
-          new String[] {Manifest.permission.ACCESS_FINE_LOCATION},
-          PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_ON_LISTEN);
+              new String[] {Manifest.permission.ACCESS_FINE_LOCATION},
+              PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_ON_LISTEN);
       // actual call will be handled in [onRequestPermissionsResult]
     } else {
       _onListen(eventSink);
     }
-  }
-
-  private void _onListen(EventChannel.EventSink eventSink) {
-    receiver = createReceiver(eventSink);
-    moContext.registerReceiver(
-        receiver, new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION));
   }
 
   @Override
@@ -716,6 +353,12 @@ public class WifiIotPlugin
       moContext.unregisterReceiver(receiver);
       receiver = null;
     }
+  }
+
+  private void _onListen(EventChannel.EventSink eventSink) {
+    receiver = createReceiver(eventSink);
+    moContext.registerReceiver(
+            receiver, new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION));
   }
 
   private BroadcastReceiver createReceiver(final EventChannel.EventSink eventSink) {
@@ -766,18 +409,18 @@ public class WifiIotPlugin
   /// Method to load wifi list into string via Callback. Returns a stringified JSONArray
   private void loadWifiList(final Result poResult) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-        && moContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            && moContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED) {
       if (requestingPermission) {
         poResult.error(
-            "WifiIotPlugin.Permission", "Only one permission can be requested at a time", null);
+                "WifiIotPlugin.Permission", "Only one permission can be requested at a time", null);
         return;
       }
       requestingPermission = true;
       permissionRequestResultCallback = poResult;
       moActivity.requestPermissions(
-          new String[] {Manifest.permission.ACCESS_FINE_LOCATION},
-          PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_LOAD_WIFI_LIST);
+              new String[] {Manifest.permission.ACCESS_FINE_LOCATION},
+              PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_LOAD_WIFI_LIST);
       // actual call will be handled in [onRequestPermissionsResult]
     } else {
       _loadWifiList(poResult);
@@ -805,7 +448,7 @@ public class WifiIotPlugin
     boolean useWifi = poCall.argument("useWifi");
 
     final ConnectivityManager manager =
-        (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+            (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
 
     boolean success = true;
     boolean shouldReply = true;
@@ -817,30 +460,30 @@ public class WifiIotPlugin
         builder.addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
         shouldReply = false;
         manager.requestNetwork(
-            builder.build(),
-            new ConnectivityManager.NetworkCallback() {
-              @Override
-              public void onAvailable(Network network) {
-                super.onAvailable(network);
-                boolean success = false;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                  success = manager.bindProcessToNetwork(network);
+                builder.build(),
+                new ConnectivityManager.NetworkCallback() {
+                  @Override
+                  public void onAvailable(Network network) {
+                    super.onAvailable(network);
+                    boolean success = false;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                      success = manager.bindProcessToNetwork(network);
 
-                } else {
-                  success = ConnectivityManager.setProcessDefaultNetwork(network);
-                }
-                manager.unregisterNetworkCallback(this);
-                final boolean result = success;
-                final Handler handler = new Handler(Looper.getMainLooper());
-                handler.post(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        poResult.success(result);
-                      }
-                    });
-              }
-            });
+                    } else {
+                      success = ConnectivityManager.setProcessDefaultNetwork(network);
+                    }
+                    manager.unregisterNetworkCallback(this);
+                    final boolean result = success;
+                    final Handler handler = new Handler(Looper.getMainLooper());
+                    handler.post(
+                            new Runnable() {
+                              @Override
+                              public void run() {
+                                poResult.success(result);
+                              }
+                            });
+                  }
+                });
 
       } else {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -881,7 +524,7 @@ public class WifiIotPlugin
         }
       } else {
         Log.e(
-            WifiIotPlugin.class.getSimpleName(), "Error `setEnabled`: shouldOpenSettings is null.");
+                WifiIotPlugin.class.getSimpleName(), "Error `setEnabled`: shouldOpenSettings is null.");
       }
     }
 
@@ -916,9 +559,9 @@ public class WifiIotPlugin
       return MacAddress.fromString(bssid);
     } catch (IllegalArgumentException invalidRepresentation) {
       Log.e(
-          WifiIotPlugin.class.getSimpleName(),
-          "Mac address parsing failed for bssid: " + bssid,
-          invalidRepresentation);
+              WifiIotPlugin.class.getSimpleName(),
+              "Mac address parsing failed for bssid: " + bssid,
+              invalidRepresentation);
       return null;
     }
   }
@@ -955,17 +598,17 @@ public class WifiIotPlugin
       } else if (security != null && security.toUpperCase().equals("WEP")) {
         // WEP is not supported
         poResult.error(
-            "Error", "WEP is not supported for Android SDK " + Build.VERSION.SDK_INT, "");
+                "Error", "WEP is not supported for Android SDK " + Build.VERSION.SDK_INT, "");
         return;
       }
 
       final ArrayList<WifiNetworkSuggestion> suggestionsList =
-          new ArrayList<WifiNetworkSuggestion>();
+              new ArrayList<WifiNetworkSuggestion>();
       suggestionsList.add(suggestedNet.build());
 
       Bundle bundle = new Bundle();
       bundle.putParcelableArrayList(
-          android.provider.Settings.EXTRA_WIFI_NETWORK_LIST, suggestionsList);
+              android.provider.Settings.EXTRA_WIFI_NETWORK_LIST, suggestionsList);
       Intent intent = new Intent(android.provider.Settings.ACTION_WIFI_ADD_NETWORKS);
       intent.putExtras(bundle);
       intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -975,7 +618,7 @@ public class WifiIotPlugin
     } else {
       // Deprecated version
       android.net.wifi.WifiConfiguration conf =
-          generateConfiguration(ssid, bssid, password, security, isHidden);
+              generateConfiguration(ssid, bssid, password, security, isHidden);
 
       int updateNetwork = registerWifiNetworkDeprecated(conf, false);
 
@@ -993,11 +636,11 @@ public class WifiIotPlugin
   /// Callback returns true if ssid is in the range
   private void findAndConnect(final MethodCall poCall, final Result poResult) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-        && moContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            && moContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED) {
       if (requestingPermission) {
         poResult.error(
-            "WifiIotPlugin.Permission", "Only one permission can be requested at a time", null);
+                "WifiIotPlugin.Permission", "Only one permission can be requested at a time", null);
         return;
       }
       requestingPermission = true;
@@ -1005,8 +648,8 @@ public class WifiIotPlugin
       permissionRequestCookie.clear();
       permissionRequestCookie.add(poCall);
       moActivity.requestPermissions(
-          new String[] {Manifest.permission.ACCESS_FINE_LOCATION},
-          PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_FIND_AND_CONNECT);
+              new String[] {Manifest.permission.ACCESS_FINE_LOCATION},
+              PERMISSIONS_REQUEST_CODE_ACCESS_FINE_LOCATION_FIND_AND_CONNECT);
       // actual call will be handled in [onRequestPermissionsResult]
     } else {
       _findAndConnect(poCall, poResult);
@@ -1027,7 +670,7 @@ public class WifiIotPlugin
         for (ScanResult result : results) {
           String resultString = "" + result.SSID;
           if (ssid.equals(resultString)
-              && (result.BSSID == null || bssid == null || result.BSSID.equals(bssid))) {
+                  && (result.BSSID == null || bssid == null || result.BSSID.equals(bssid))) {
             security = getSecurityType(result);
             if (bssid == null) {
               bssid = result.BSSID;
@@ -1044,8 +687,8 @@ public class WifiIotPlugin
     String capabilities = scanResult.capabilities;
 
     if (capabilities.contains("WPA")
-        || capabilities.contains("WPA2")
-        || capabilities.contains("WPA/WPA2 PSK")) {
+            || capabilities.contains("WPA2")
+            || capabilities.contains("WPA/WPA2 PSK")) {
       return "WPA";
     } else if (capabilities.contains("WEP")) {
       return "WEP";
@@ -1060,17 +703,17 @@ public class WifiIotPlugin
       isConnectedDeprecated(poResult);
     } else {
       if (moContext.checkSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)
-          != PackageManager.PERMISSION_GRANTED) {
+              != PackageManager.PERMISSION_GRANTED) {
         if (requestingPermission) {
           poResult.error(
-              "WifiIotPlugin.Permission", "Only one permission can be requested at a time", null);
+                  "WifiIotPlugin.Permission", "Only one permission can be requested at a time", null);
           return;
         }
         requestingPermission = true;
         permissionRequestResultCallback = poResult;
         moActivity.requestPermissions(
-            new String[] {Manifest.permission.ACCESS_NETWORK_STATE},
-            PERMISSIONS_REQUEST_CODE_ACCESS_NETWORK_STATE_IS_CONNECTED);
+                new String[] {Manifest.permission.ACCESS_NETWORK_STATE},
+                PERMISSIONS_REQUEST_CODE_ACCESS_NETWORK_STATE_IS_CONNECTED);
         // actual call will be handled in [onRequestPermissionsResult]
       } else {
         _isConnected(poResult);
@@ -1080,16 +723,16 @@ public class WifiIotPlugin
 
   private void _isConnected(Result poResult) {
     ConnectivityManager connManager =
-        (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+            (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
     boolean result = false;
     if (connManager != null) {
       // `connManager.getActiveNetwork` only return if the network has internet
       // therefore using `connManager.getAllNetworks()` to check all networks
       for (final Network network : connManager.getAllNetworks()) {
         final NetworkCapabilities capabilities =
-            network != null ? connManager.getNetworkCapabilities(network) : null;
+                network != null ? connManager.getNetworkCapabilities(network) : null;
         final boolean isConnected =
-            capabilities != null && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+                capabilities != null && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
         if (isConnected) {
           result = true;
           break;
@@ -1103,9 +746,9 @@ public class WifiIotPlugin
   @SuppressWarnings("deprecation")
   private void isConnectedDeprecated(Result poResult) {
     ConnectivityManager connManager =
-        (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+            (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
     android.net.NetworkInfo mWifi =
-        connManager != null ? connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI) : null;
+            connManager != null ? connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI) : null;
 
     poResult.success(mWifi != null && mWifi.isConnected());
   }
@@ -1123,7 +766,7 @@ public class WifiIotPlugin
     } else {
       if (networkCallback != null) {
         final ConnectivityManager connectivityManager =
-            (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+                (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.unregisterNetworkCallback(networkCallback);
         networkCallback = null;
         disconnected = true;
@@ -1132,8 +775,8 @@ public class WifiIotPlugin
         disconnected = networksRemoved == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS;
       } else {
         Log.e(
-            WifiIotPlugin.class.getSimpleName(),
-            "Can't disconnect from WiFi, networkCallback and networkSuggestions is null.");
+                WifiIotPlugin.class.getSimpleName(),
+                "Can't disconnect from WiFi, networkCallback and networkSuggestions is null.");
       }
     }
     poResult.success(disconnected);
@@ -1200,7 +843,7 @@ public class WifiIotPlugin
       List<android.net.wifi.WifiConfiguration> mWifiConfigList = moWiFi.getConfiguredNetworks();
       for (android.net.wifi.WifiConfiguration wifiConfig : mWifiConfigList) {
         String comparableSSID =
-            ('"' + prefix_ssid + '"'); //Add quotes because wifiConfig.SSID has them
+                ('"' + prefix_ssid + '"'); //Add quotes because wifiConfig.SSID has them
         if (wifiConfig.SSID.equals(comparableSSID)) {
           Boolean isRemoved = moWiFi.removeNetwork(wifiConfig.networkId);
           if (isRemoved) {
@@ -1273,36 +916,36 @@ public class WifiIotPlugin
 
   /// Method to connect to WIFI Network
   private void connectTo(
-      final Result poResult,
-      final String ssid,
-      final String bssid,
-      final String password,
-      final String security,
-      final Boolean joinOnce,
-      final Boolean withInternet,
-      final Boolean isHidden) {
+          final Result poResult,
+          final String ssid,
+          final String bssid,
+          final String password,
+          final String security,
+          final Boolean joinOnce,
+          final Boolean withInternet,
+          final Boolean isHidden) {
     final Handler handler = new Handler(Looper.getMainLooper());
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
       final boolean connected =
-          connectToDeprecated(ssid, bssid, password, security, joinOnce, isHidden);
+              connectToDeprecated(ssid, bssid, password, security, joinOnce, isHidden);
       handler.post(
-          new Runnable() {
-            @Override
-            public void run() {
-              poResult.success(connected);
-            }
-          });
+              new Runnable() {
+                @Override
+                public void run() {
+                  poResult.success(connected);
+                }
+              });
     } else {
       // error if WEP security, since not supported
       if (security != null && security.toUpperCase().equals("WEP")) {
         handler.post(
-            new Runnable() {
-              @Override
-              public void run() {
-                poResult.error(
-                    "Error", "WEP is not supported for Android SDK " + Build.VERSION.SDK_INT, "");
-              }
-            });
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    poResult.error(
+                            "Error", "WEP is not supported for Android SDK " + Build.VERSION.SDK_INT, "");
+                  }
+                });
         return;
       }
 
@@ -1316,12 +959,12 @@ public class WifiIotPlugin
           final MacAddress macAddress = macAddressFromBssid(bssid);
           if (macAddress == null) {
             handler.post(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    poResult.error("Error", "Invalid BSSID representation", "");
-                  }
-                });
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        poResult.error("Error", "Invalid BSSID representation", "");
+                      }
+                    });
             return;
           }
           builder.setBssid(macAddress);
@@ -1350,12 +993,12 @@ public class WifiIotPlugin
         Log.e(WifiIotPlugin.class.getSimpleName(), "status: " + status);
 
         handler.post(
-            new Runnable() {
-              @Override
-              public void run() {
-                poResult.success(status == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS);
-              }
-            });
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    poResult.success(status == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS);
+                  }
+                });
       } else {
         // Make new network specifier
         final WifiNetworkSpecifier.Builder builder = new WifiNetworkSpecifier.Builder();
@@ -1366,12 +1009,12 @@ public class WifiIotPlugin
           final MacAddress macAddress = macAddressFromBssid(bssid);
           if (macAddress == null) {
             handler.post(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    poResult.error("Error", "Invalid BSSID representation", "");
-                  }
-                });
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        poResult.error("Error", "Invalid BSSID representation", "");
+                      }
+                    });
             return;
           }
           builder.setBssid(macAddress);
@@ -1383,39 +1026,39 @@ public class WifiIotPlugin
         }
 
         final NetworkRequest networkRequest =
-            new NetworkRequest.Builder()
-                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-                .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .setNetworkSpecifier(builder.build())
-                .build();
+                new NetworkRequest.Builder()
+                        .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                        .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                        .setNetworkSpecifier(builder.build())
+                        .build();
 
         final ConnectivityManager connectivityManager =
-            (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+                (ConnectivityManager) moContext.getSystemService(Context.CONNECTIVITY_SERVICE);
 
         if (networkCallback != null) connectivityManager.unregisterNetworkCallback(networkCallback);
 
         networkCallback =
-            new ConnectivityManager.NetworkCallback() {
-              boolean resultSent = false;
+                new ConnectivityManager.NetworkCallback() {
+                  boolean resultSent = false;
 
-              @Override
-              public void onAvailable(@NonNull Network network) {
-                super.onAvailable(network);
-                if (!resultSent) {
-                  poResult.success(true);
-                  resultSent = true;
-                }
-              }
+                  @Override
+                  public void onAvailable(@NonNull Network network) {
+                    super.onAvailable(network);
+                    if (!resultSent) {
+                      poResult.success(true);
+                      resultSent = true;
+                    }
+                  }
 
-              @Override
-              public void onUnavailable() {
-                super.onUnavailable();
-                if (!resultSent) {
-                  poResult.success(false);
-                  resultSent = true;
-                }
-              }
-            };
+                  @Override
+                  public void onUnavailable() {
+                    super.onUnavailable();
+                    if (!resultSent) {
+                      poResult.success(false);
+                      resultSent = true;
+                    }
+                  }
+                };
 
         connectivityManager.requestNetwork(networkRequest, networkCallback, handler, 30 * 1000);
       }
@@ -1424,7 +1067,7 @@ public class WifiIotPlugin
 
   @SuppressWarnings("deprecation")
   private int registerWifiNetworkDeprecated(
-      android.net.wifi.WifiConfiguration conf, Boolean joinOnce) {
+          android.net.wifi.WifiConfiguration conf, Boolean joinOnce) {
     int updateNetwork = -1;
     int registeredNetwork = -1;
 
@@ -1434,7 +1077,7 @@ public class WifiIotPlugin
     if (mWifiConfigList != null) {
       for (android.net.wifi.WifiConfiguration wifiConfig : mWifiConfigList) {
         if (wifiConfig.SSID.equals(conf.SSID)
-            && (wifiConfig.BSSID == null
+                && (wifiConfig.BSSID == null
                 || conf.BSSID == null
                 || wifiConfig.BSSID.equals(conf.BSSID))) {
           conf.networkId = wifiConfig.networkId;
@@ -1462,15 +1105,15 @@ public class WifiIotPlugin
               int ssidRandomizedExtraLength = ssidRandomized.length() - 32;
               if (ssidRandomizedExtraLength > 0) {
                 ssidRandomized =
-                    ssid.substring(0, ssid.length() - ssidRandomizedExtraLength) + randomInteger;
+                        ssid.substring(0, ssid.length() - ssidRandomizedExtraLength) + randomInteger;
               }
               conf.SSID = "\"" + ssidRandomized + "\"";
               updateNetwork = moWiFi.addNetwork(conf); // Add my wifi with another name
               conf.SSID = ssid;
               conf.networkId = updateNetwork;
               updateNetwork =
-                  moWiFi.updateNetwork(
-                      conf); // After my wifi is added with another name, I change it to the desired name
+                      moWiFi.updateNetwork(
+                              conf); // After my wifi is added with another name, I change it to the desired name
               moWiFi.saveConfiguration();
               if (updateNetwork != -1) {
                 break;
@@ -1499,7 +1142,7 @@ public class WifiIotPlugin
   }
 
   private android.net.wifi.WifiConfiguration generateConfiguration(
-      String ssid, String bssid, String password, String security, Boolean isHidden) {
+          String ssid, String bssid, String password, String security, Boolean isHidden) {
     android.net.wifi.WifiConfiguration conf = new android.net.wifi.WifiConfiguration();
     conf.SSID = "\"" + ssid + "\"";
     conf.hiddenSSID = isHidden != null ? isHidden : false;
@@ -1546,15 +1189,15 @@ public class WifiIotPlugin
 
   @SuppressWarnings("deprecation")
   private Boolean connectToDeprecated(
-      String ssid,
-      String bssid,
-      String password,
-      String security,
-      Boolean joinOnce,
-      Boolean isHidden) {
+          String ssid,
+          String bssid,
+          String password,
+          String security,
+          Boolean joinOnce,
+          Boolean isHidden) {
     /// Make new configuration
     android.net.wifi.WifiConfiguration conf =
-        generateConfiguration(ssid, bssid, password, security, isHidden);
+            generateConfiguration(ssid, bssid, password, security, isHidden);
 
     int updateNetwork = registerWifiNetworkDeprecated(conf, joinOnce);
 
@@ -1611,5 +1254,343 @@ public class WifiIotPlugin
       moWiFi.enableNetwork(lastConnectedNetworkId, true);
     }
     return connected;
+  }
+
+  /**
+   * The network's SSID. Can either be an ASCII string, which must be enclosed in double quotation
+   * marks (e.g., {@code "MyNetwork"}), or a string of hex digits, which are not enclosed in quotes
+   * (e.g., {@code 01a243f405}).
+   */
+  private void getWiFiAPSSID(Result poResult) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
+
+      if (oWiFiConfig != null && oWiFiConfig.SSID != null) {
+        poResult.success(oWiFiConfig.SSID);
+        return;
+      }
+
+      poResult.error("Exception [getWiFiAPSSID]", "SSID not found", null);
+    } else {
+      if (apReservation != null) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+          WifiConfiguration wifiConfiguration = apReservation.getWifiConfiguration();
+          if (wifiConfiguration != null) {
+            poResult.success(wifiConfiguration.SSID);
+          } else {
+            poResult.error(
+                    "Exception [getWiFiAPSSID]",
+                    "Security type is not WifiConfiguration.KeyMgmt.None or WifiConfiguration.KeyMgmt.WPA2_PSK",
+                    null);
+          }
+        } else {
+          SoftApConfiguration softApConfiguration = apReservation.getSoftApConfiguration();
+          poResult.success(softApConfiguration.getSsid());
+        }
+      } else {
+        poResult.error("Exception [getWiFiAPSSID]", "Hotspot is not enabled.", null);
+      }
+    }
+  }
+
+  private void setWiFiAPSSID(MethodCall poCall, Result poResult) {
+    String sAPSSID = poCall.argument("ssid");
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
+
+      oWiFiConfig.SSID = sAPSSID;
+
+      moWiFiAPManager.setWifiApConfiguration(oWiFiConfig);
+
+      poResult.success(null);
+    } else {
+      poResult.error(
+              "Exception [setWiFiAPSSID]",
+              "Setting SSID name is not supported on API level >= 26",
+              null);
+    }
+  }
+
+  /**
+   * This is a network that does not broadcast its SSID, so an SSID-specific probe request must be
+   * used for scans.
+   */
+  private void isSSIDHidden(Result poResult) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
+
+      if (oWiFiConfig != null && oWiFiConfig.hiddenSSID) {
+        poResult.success(oWiFiConfig.hiddenSSID);
+        return;
+      }
+
+      poResult.error("Exception [isSSIDHidden]", "Wifi AP not Supported", null);
+    } else {
+      if (apReservation != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          SoftApConfiguration softApConfiguration = apReservation.getSoftApConfiguration();
+          poResult.success(softApConfiguration.isHiddenSsid());
+        } else {
+          WifiConfiguration wifiConfiguration = apReservation.getWifiConfiguration();
+          if (wifiConfiguration != null) {
+            poResult.success(wifiConfiguration.hiddenSSID);
+          } else {
+            poResult.error(
+                    "Exception [isSSIDHidden]",
+                    "Security type is not WifiConfiguration.KeyMgmt.None or WifiConfiguration.KeyMgmt.WPA2_PSK",
+                    null);
+          }
+        }
+      } else {
+        poResult.error("Exception [isSSIDHidden]", "Hotspot is not enabled.", null);
+      }
+    }
+  }
+
+  private void setSSIDHidden(MethodCall poCall, Result poResult) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      boolean isSSIDHidden = poCall.argument("hidden");
+
+      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
+
+      oWiFiConfig.hiddenSSID = isSSIDHidden;
+
+      moWiFiAPManager.setWifiApConfiguration(oWiFiConfig);
+
+      poResult.success(null);
+    } else {
+      poResult.error(
+              "Exception [setSSIDHidden]",
+              "Setting SSID visibility is not supported on API level >= 26",
+              null);
+    }
+  }
+
+  /**
+   * Pre-shared key for use with WPA-PSK. Either an ASCII string enclosed in double quotation marks
+   * (e.g., {@code "abcdefghij"} for PSK passphrase or a string of 64 hex digits for raw PSK.
+   *
+   * <p>When the value of this key is read, the actual key is not returned, just a "*" if the key
+   * has a value, or the null string otherwise.
+   */
+  private void getWiFiAPPreSharedKey(Result poResult) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
+
+      if (oWiFiConfig != null && oWiFiConfig.preSharedKey != null) {
+        poResult.success(oWiFiConfig.preSharedKey);
+        return;
+      }
+
+      poResult.error("Exception", "Wifi AP not Supported", null);
+    } else {
+      if (apReservation != null) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+          WifiConfiguration wifiConfiguration = apReservation.getWifiConfiguration();
+          if (wifiConfiguration != null) {
+            poResult.success(wifiConfiguration.preSharedKey);
+          } else {
+            poResult.error(
+                    "Exception [getWiFiAPPreSharedKey]",
+                    "Security type is not WifiConfiguration.KeyMgmt.None or WifiConfiguration.KeyMgmt.WPA2_PSK",
+                    null);
+          }
+        } else {
+          SoftApConfiguration softApConfiguration = apReservation.getSoftApConfiguration();
+          poResult.success(softApConfiguration.getPassphrase());
+        }
+      } else {
+        poResult.error("Exception [getWiFiAPPreSharedKey]", "Hotspot is not enabled.", null);
+      }
+    }
+  }
+
+  private void setWiFiAPPreSharedKey(MethodCall poCall, Result poResult) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      String sPreSharedKey = poCall.argument("preSharedKey");
+
+      android.net.wifi.WifiConfiguration oWiFiConfig = moWiFiAPManager.getWifiApConfiguration();
+
+      oWiFiConfig.preSharedKey = sPreSharedKey;
+
+      moWiFiAPManager.setWifiApConfiguration(oWiFiConfig);
+
+      poResult.success(null);
+    } else {
+      poResult.error(
+              "Exception [setWiFiAPPreSharedKey]",
+              "Setting WiFi password is not supported on API level >= 26",
+              null);
+    }
+  }
+
+  /**
+   * Gets a list of the clients connected to the Hotspot *** getClientList : param onlyReachables
+   * {@code false} if the list should contain unreachable (probably disconnected) clients, {@code
+   * true} otherwise param reachableTimeout Reachable Timout in miliseconds, 300 is default param
+   * finishListener, Interface called when the scan method finishes
+   */
+  private void getClientList(MethodCall poCall, final Result poResult) {
+    Boolean onlyReachables = false;
+    if (poCall.argument("onlyReachables") != null) {
+      onlyReachables = poCall.argument("onlyReachables");
+    }
+
+    Integer reachableTimeout = 300;
+    if (poCall.argument("reachableTimeout") != null) {
+      reachableTimeout = poCall.argument("reachableTimeout");
+    }
+
+    final Boolean finalOnlyReachables = onlyReachables;
+    FinishScanListener oFinishScanListener =
+            new FinishScanListener() {
+              @Override
+              public void onFinishScan(final ArrayList<ClientScanResult> clients) {
+                try {
+                  JSONArray clientArray = new JSONArray();
+
+                  for (ClientScanResult client : clients) {
+                    JSONObject clientObject = new JSONObject();
+
+                    Boolean clientIsReachable = client.isReachable();
+                    Boolean shouldReturnCurrentClient = true;
+                    if (finalOnlyReachables.booleanValue()) {
+                      if (!clientIsReachable.booleanValue()) {
+                        shouldReturnCurrentClient = Boolean.valueOf(false);
+                      }
+                    }
+                    if (shouldReturnCurrentClient.booleanValue()) {
+                      try {
+                        clientObject.put("IPAddr", client.getIpAddr());
+                        clientObject.put("HWAddr", client.getHWAddr());
+                        clientObject.put("Device", client.getDevice());
+                        clientObject.put("isReachable", client.isReachable());
+                      } catch (JSONException e) {
+                        poResult.error("Exception", e.getMessage(), null);
+                      }
+                      clientArray.put(clientObject);
+                    }
+                  }
+                  poResult.success(clientArray.toString());
+                } catch (Exception e) {
+                  poResult.error("Exception", e.getMessage(), null);
+                }
+              }
+            };
+
+    if (reachableTimeout != null) {
+      moWiFiAPManager.getClientList(onlyReachables, reachableTimeout, oFinishScanListener);
+    } else {
+      moWiFiAPManager.getClientList(onlyReachables, oFinishScanListener);
+    }
+  }
+
+  /** Gets the Wi-Fi enabled state. *** getWifiApState : return {link WIFI_AP_STATE} */
+  private void getWiFiAPState(Result poResult) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      poResult.success(moWiFiAPManager.getWifiApState().ordinal());
+    } else {
+      poResult.success(localOnlyHotspotState);
+    }
+  }
+
+  /**
+   * Return whether Wi-Fi AP is enabled or disabled. *** isWifiApEnabled : return {@code true} if
+   * Wi-Fi AP is enabled
+   */
+  private void isWiFiAPEnabled(Result poResult) {
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      try {
+        poResult.success(moWiFiAPManager.isWifiApEnabled());
+      } catch (SecurityException e) {
+        Log.e(WifiIotPlugin.class.getSimpleName(), e.getMessage(), null);
+        poResult.error("Exception [isWiFiAPEnabled]", e.getMessage(), null);
+      }
+    } else {
+      poResult.success(apReservation != null);
+    }
+  }
+
+  /**
+   * Start AccessPoint mode with the specified configuration. If the radio is already running in AP
+   * mode, update the new configuration Note that starting in access point mode disables station
+   * mode operation *** setWifiApEnabled : param wifiConfig SSID, security and channel details as
+   * part of WifiConfiguration return {@code true} if the operation succeeds, {@code false}
+   * otherwise
+   */
+  private void setWiFiAPEnabled(MethodCall poCall, final Result poResult) {
+    boolean enabled = poCall.argument("state");
+
+    /** Using LocalOnlyHotspotCallback when setting WiFi AP state on API level >= 29 */
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      final boolean result = moWiFiAPManager.setWifiApEnabled(null, enabled);
+      poResult.success(result);
+    } else {
+      if (enabled) {
+        localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_ENABLING;
+        moWiFi.startLocalOnlyHotspot(
+                new WifiManager.LocalOnlyHotspotCallback() {
+                  @Override
+                  public void onStarted(WifiManager.LocalOnlyHotspotReservation reservation) {
+                    super.onStarted(reservation);
+                    apReservation = reservation;
+                    localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_ENABLED;
+                    poResult.success(true);
+                  }
+
+                  @Override
+                  public void onStopped() {
+                    super.onStopped();
+                    if (apReservation != null) {
+                      apReservation.close();
+                    }
+                    apReservation = null;
+                    localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_DISABLED;
+                    Log.d(WifiIotPlugin.class.getSimpleName(), "LocalHotspot Stopped.");
+                  }
+
+                  @Override
+                  public void onFailed(int reason) {
+                    super.onFailed(reason);
+                    if (apReservation != null) {
+                      apReservation.close();
+                    }
+                    apReservation = null;
+                    localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_FAILED;
+                    Log.d(
+                            WifiIotPlugin.class.getSimpleName(),
+                            "LocalHotspot failed with code: " + String.valueOf(reason));
+                    poResult.success(false);
+                  }
+                },
+                new Handler());
+      } else {
+        localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_DISABLING;
+        if (apReservation != null) {
+          apReservation.close();
+          apReservation = null;
+          poResult.success(true);
+        } else {
+          Log.e(
+                  WifiIotPlugin.class.getSimpleName(), "Can't disable WiFi AP, apReservation is null.");
+          poResult.success(false);
+        }
+        localOnlyHotspotState = WIFI_AP_STATE.WIFI_AP_STATE_DISABLED;
+      }
+    }
+  }
+
+  /**
+   * Show write permission settings page to user Depending on Android version and application these
+   * may be needed to perform certain WiFi configurations that require WRITE_SETTINGS which require
+   * a double opt-in, not just presence in manifest. *** showWritePermissionSettings : param boolean
+   * force, if true shows always, if false only if permissions are not already granted
+   */
+  private void showWritePermissionSettings(MethodCall poCall, Result poResult) {
+    boolean force = poCall.argument("force");
+    moWiFiAPManager.showWritePermissionSettings(force);
+    poResult.success(null);
   }
 }


### PR DESCRIPTION
Fixed an issue on Android < Q where if the user already successfully  connected to the network before, a new connection request with a wrong password would succeed. (Tested on Android 8.1 OnePlus 5T)

Changed the WIFI behavior when disconnecting from an app-created network on Android < Q to be loosely similar to observed behvaior on Android 11 (OnePlus 7 Pro) where the device will try to reconnect to the previously connected network.

This branch was created because the previous contribution from @lmmfranco didn't work for me. I hope it doesn't affect his work either and it can work for everyone who faced this issue.

The code might be a little messy, feel free to edit it out to fix inconsistencies.